### PR TITLE
fix: server process won't die

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -24,7 +24,7 @@ def flask_server__env():
 
     Can be ``development`` or ``production``.
     """
-    return "development"
+    return "production"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Change the mode of the Flask server to `production` instead of `development`.

The mode of the Flask server dictates how the server will respond to SIGTERM, SIGKILL,
and other signals. A keyboard interrupt is pretty much the easiest way to kill the
server in `development` mode. Changing the mode to `production` makes it easy to kill
the server with a SIGTERM.

Closes #10 .