### PR TITLE
Breakup `log_data` fixture

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,12 +8,18 @@ from app.models import HttpUrl  # type: ignore[import]
 
 
 @pytest.fixture(scope="module")
-def log_data() -> list[str]:
-    """Return a sample of log data for testing."""
+def log_json_data() -> list[dict[str, str]]:
+    """Return a sample of log data as dict."""
     with open("tests/data/log_data.json", encoding="utf-8") as fp:
         json_data: list[dict[str, str]] = json.load(fp)
+    return json_data
+
+
+@pytest.fixture(scope="module")
+def log_data(log_json_data: list[dict[str, str]]) -> list[str]:
+    """Return a sample of log data as JSON strings."""
     data: list[str] = []
-    for log in json_data:
+    for log in log_json_data:
         data.append(json.dumps(log))
     return data
 


### PR DESCRIPTION
Breakup `log_data` fixture in `tests/fixtures.py` into 2 fixtures:

- `log_json_data`: Read from file and return the dict.
- `log_data`: Take `dict` and return JSON strings.

This uncouples the file read from the creation of JSON strings. And it allows us to
easily expose the `dict` of JSON objects, which can be used as fixtures in other
tests that want a `dict`, not `str`.

Closes #15.