### PR TITLE
Add a function to asynchronously transmit logs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,136 @@ from __future__ import annotations  # Remove if using python3.10 or greater
 
 import json
 import logging
+from enum import Enum
 from pathlib import Path
+from typing import Any
+
+from aiohttp import (
+    ClientConnectionError,
+    ClientOSError,
+    ClientSession,
+    ContentTypeError,
+)
+
+from app.models import HttpUrl  # type: ignore[import]  # Ignore missing imports
+
+
+class ErrorType(Enum):
+    """Enumerate categories of transmission errors than can be encountered.
+
+    Errors during transmission can occur due to a variety of factors. This enum can be
+    used to classify errors based on the set of factors that cause them. This will be
+    helpful in adding structure to how errors are addressed.
+
+    Examples:
+        >>> from app.config import ErrorType
+        >>> try:
+        ...     raise ValueError("Some content error happens.")
+        ... except ValueError:
+        ...     raise ValueError(f"type:{ErrorType.ContentType}")
+        Traceback (most recent call last):
+            File "<stdin>", line 2, in <module>
+        ValueError: Some content error happens.
+
+        During handling of the above exception, another exception occurred:
+
+        Traceback (most recent call last):
+            File "<stdin>", line 4, in <module>
+        ValueError: type:ErrorType.ContentType
+    """
+
+    ContentType = "ContentType"
+    Header = "Header"
+    System = "System"
+    Connection = "Connection"
+
+
+class ResponseError(Exception):
+    """Error in the response.
+
+    A request can successfully return a response, but the response itself might contain
+    errors that should be raised as exception.
+
+    Args:
+        types: Types of error information.
+        message: Description of the error.
+        partial_message: Data returned in the response, formatted as string.
+        status_code: Status code returned by the response.
+        headers: Headers returned by the response.
+        request_info (optional): Information about the request preceding the response.
+
+    Examples:
+        >>> from app.config import ResponseError, ErrorType
+        >>> import requests
+        >>> with requests.get(url="http://httpbin.org/get") as response:
+        ...     response_text = response.text
+        ...     response_status_code = response.status_code
+        ...     if response_status_code == 200:
+        ...         raise ResponseError(
+        ...             types=(ErrorType.ContentType,),
+        ...             message="There is an error in the content type header. Should be a form of text.",
+        ...             partial_message=response_text,
+        ...             status_code=response.status_code,
+        ...             headers=response.headers,
+        ...             request_info=response.request,
+        ...         )
+        Traceback (most recent call last):
+          File "<stdin>", line 5, in <module>
+        app.config.ResponseError: There is an error in the content type header. Should be a form of text.
+    """
+
+    def __init__(
+        self,
+        types: tuple[ErrorType, ...],
+        message: str,
+        partial_message: str,
+        status_code: int,
+        headers: Any,
+        request_info: Any | None,
+    ):
+        self.types = types
+        self.message = message
+        self.partial_message = partial_message
+        self.status_code = status_code
+        self.headers = headers
+        self.request_info = request_info
+
+        super().__init__(self.message)
+
+
+class TransmissionError(Exception):
+    """Error in any stage of the transmission.
+
+    Args:
+        types: Types of error information.
+        message: Description of the error.
+
+    Examples:
+        >>> from app.config import TransmissionError, ErrorType
+        >>> import requests
+        >>> try:
+        ...     requests.get("http://httpbiin.org/ge")
+        ... except:
+        ...     raise TransmissionError(
+        ...         types=(ErrorType.Connection, ErrorType.System),
+        ...         message="There was an error during transmission.",
+        ...     )
+        Traceback (most recent call last):...
+        socket.gaierror: [Errno 11001] getaddrinfo failed
+
+        During handling of the above exception, another exception occurred:
+
+        Traceback (most recent call last):
+        File "<stdin>", line 4, in <module>
+        app.config.TransmissionError: There was an error during transmission.
+    """
+
+    def __init__(self, types: tuple[ErrorType, ...], message: str):
+        self.types = types
+        self.message = message
+
+        super().__init__(self.message)
+
 
 log_formatter = logging.Formatter(
     json.dumps(
@@ -135,3 +264,76 @@ def create_handlers(
     file_handler.setLevel(log_level)
 
     return stream_handler, file_handler
+
+
+async def async_transmit_log(
+    log_data: str,
+    session: ClientSession,
+    url: HttpUrl,
+) -> tuple[str, int]:
+    """Asynchronously POST log data to given url using session.
+
+    This function uses the ClientSession object to POST logs to the server URL. It
+    assumes that the ClientSession will not close during transmission, that the URL is
+    valid and working, and that the log data is a valid payload.
+
+    Args:
+        log_data: The log data to be transmitted.
+        session: The ClientSession object to be used to POST data. Assumes all
+        correct headers are already assigned.
+        url: Validated ``HttpUrl`` of the log server. The ``str`` of this url will be
+        used.
+
+    Returns:
+        tuple[str, int]: A tuple comprised of the response text and the status code.
+
+    Raises:
+        ResponseError: If there is an error in the response.
+        TransmissionError: If there is an error during any part of the transmission.
+
+    Examples:
+        The ``session`` param should be created within a context manager.
+
+        >>> import asyncio, aiohttp
+        >>> from app.models import HttpUrl
+        >>> asyncio.run(
+        ... async_transmit_log(
+        ...     log_data="This is a log",
+        ...     session=aiohttp.ClientSession(
+        ...         headers={"Content-Type": "application/json"}
+        ...         ),
+        ...     url=HttpUrl(url="localhost:3000/log/")
+        ...     )
+        ... )
+        'Received JSON Data as POST for 4c4de413-bfbe-4024-9c5c-ae8cc7bf636a', 200
+
+    """
+    url_str = str(url.url)
+    try:
+        async with session.post(url_str, data=log_data) as response:
+            response_text = await response.text()
+            response_status_code = response.status
+    except ContentTypeError as e:
+        raise ResponseError(
+            types=(ErrorType.ContentType,),
+            message="There is an error in the content type header. Should be a form of text.",
+            partial_message=e.message,
+            status_code=e.status,
+            headers=e.headers,
+            request_info=e.request_info,
+        )
+    except ClientConnectionError:
+        raise TransmissionError(
+            types=(
+                ErrorType.Connection,
+                ErrorType.System,
+            ),
+            message="There was an error during connection to the log server.",
+        )
+    except ClientOSError:
+        raise TransmissionError(
+            types=(ErrorType.System,),
+            message="There was a low level error during transmission of the log.",
+        )
+
+    return response_text, response_status_code

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,7 @@ import asyncio
 import pytest
 from aiohttp import ClientSession
 
-from app.config import (
-    async_transmit_log,
-)  # type: ignore[import]  # Ignore missing imports
+from app.config import async_transmit_log  # type: ignore[import]  # Ignore missing imports
 from app.models import HttpUrl  # type: ignore[import]  # Ignore missing imports
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+"""Test the code at app/config.py."""
+import asyncio
+
+import pytest
+from aiohttp import ClientSession
+
+from app.config import (
+    async_transmit_log,
+)  # type: ignore[import]  # Ignore missing imports
+from app.models import HttpUrl  # type: ignore[import]  # Ignore missing imports
+
+
+@pytest.mark.asyncio
+async def test_async_transmit_log(log_data: list[str], flask_server_port, n_space):
+    """GIVEN: log data.
+
+    WHEN: ``async_transmit_log`` is used to transmit logs.
+
+    THEN: Response is correct confirmation message and status code.
+    """
+    namespace: str = n_space
+    log_url = HttpUrl(
+        url=f"http://localhost:{flask_server_port}/log/namespaces/{namespace}/"
+    )
+    confirm_msg = f"Received JSON Data as POST for {namespace}"
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+
+    async with ClientSession(headers=headers) as session:
+        tasks = []
+        for log in log_data:
+            tasks.append(
+                asyncio.create_task(
+                    async_transmit_log(log_data=log, session=session, url=log_url)
+                )
+            )
+        responses: list[tuple[str, int]] = await asyncio.gather(*tasks)
+
+    for response_text, response_status in responses:
+        assert (response_text, response_status) == (
+            confirm_msg,
+            200,
+        ), "Couldn't save log message."


### PR DESCRIPTION
Add a function to asynchronously transmit logs to the server.

Transmission of log records should be done asynchronously, to prevent blocking the
thread. A durable `aiohttp.ClientSession` object should be used as the session to
prevent recreating the session with each request. Also, a validated URL should be used.
This function was created with these requirements in mind.

Errors can happen during transmission, or when the response is interacted with.
`TransmissionError` and `ResponseError` were created to be raised when these errors are
encountered.

The process of transmission can cause errors. These errors can be classified into
multiple types, so an `enum` was created to classify them easily.

Closes #13.