### PR TITLE
Change task completion call back

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -440,11 +440,14 @@ async def transmission_loop(
     """
     loop = asyncio.get_running_loop()
 
-    tasks = set()
+    tasks: set[asyncio.Task] = set()
 
     headers: dict[str, str] = {"Content-Type": "application/json"}
 
     transmissions = qsize
+
+    def done_callback(task: asyncio.Task):
+        resolve_transmission(tasks=tasks, task=task)
 
     async with ClientSession(headers=headers) as session:
         while True:
@@ -458,7 +461,7 @@ async def transmission_loop(
                 async_transmit_log(log_data=log_data, session=session, url=log_url)
             )
             tasks.add(task)
-            task.add_done_callback(tasks.discard)
+            task.add_done_callback(done_callback)
 
         await asyncio.sleep(3)
 


### PR DESCRIPTION
Change task completion call back in `transmission_loop` to use `resolve_transmission`.

Since no behavioral changes are necessary, no additional tests were created.

The callback in `add_done_callback` will be called with only a single argument, the task
itself. Thus, the `resolve_transmission` function which takes up to 3 argument needs to
be encapsulated inside an interface, which is `done_callback`.

Closes #48,