### PR TITLE
fix: Add better separator

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -361,7 +361,7 @@ class LogJSONFormatter(logging.Formatter):
         msg = record.getMessage()
         asctime = self.formatTime(record, self.datefmt)
         if exception_msg:
-            msg = msg + " | " + exception_msg
+            msg = msg + " | Execution Information: | " + exception_msg
         return self.json_format(record=record, asctime=asctime, msg=msg)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -800,10 +800,9 @@ class TestLogJSONFormatter:
         messages: set[str] = set()
         for log_dict in call_LogJSONFormatter.log_dicts:
             try:
-                if " | " in log_dict["message"][:20]:
-                    msg = log_dict["message"][:20]
-                    index = msg.find(" | ")
-                    msg = msg[:index]
+                if " | Execution Information: | " in log_dict["message"]:
+                    idx = log_dict["message"].find(" | Execution Information: | ")
+                    msg = log_dict["message"][:idx]
                     messages.add(msg)
                 else:
                     messages.add(log_dict["message"])


### PR DESCRIPTION
Add a better separator between message and execution info in
`LogJSONFormatter.format`.

The previous separator ` | ` is inadequate, since `|` may be used in other parts of the
log message as well. The new separator is more distinguishable.

Closes #64.