### PR TITLE
Display duration of pytest runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --verbose --strict-markers
+addopts = --verbose --strict-markers --durations=10 --durations-min=0.01
 minversion = 7.1.2
 pythonpath = ./
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
Display the top 10 durations of pytest runs.

Fast tests help developers iterate faster, promote progressive enhancement, and overall increase developer experience quality. To create fast tests, we must first know which tests are slow. This change will show us the slowest 10 tests.

Closes #21.