### PR TITLE
Create parallel CI python file

### DIFF
--- a/.github/workflows/gen_json_check_formatting.py
+++ b/.github/workflows/gen_json_check_formatting.py
@@ -1,0 +1,63 @@
+"""Generate json for md report.
+
+This python script is used to generate the json for the
+markdown report generated in the workflow jobs.
+"""
+
+import json
+import os
+
+metrics = {}
+
+metrics["name"] = "Check code formatting with black"
+metrics["id"] = "check-formatting"
+
+env_info = {}
+
+try:
+    env_info["cache_hit"] = os.environ["cache_hit"]
+    if env_info["cache_hit"] == "true":
+        env_info["cache_hit"] = True
+    elif env_info["cache_hit"] == "false" or env_info["cache_hit"] == "":
+        env_info["cache_hit"] = False
+    else:
+        unknown_cache_hit_val = os.environ.get("cache_hit")
+        raise ValueError(f"Unknown value for key 'cache_hit':{unknown_cache_hit_val}")
+except KeyError:
+    env_info["cache_hit"] = None
+
+try:
+    env_info["python_ver"] = os.environ["python_ver"]
+except KeyError:
+    env_info["python_ver"] = None
+
+try:
+    env_info["pip_ver"] = os.environ["pip_ver"]
+except KeyError:
+    env_info["pip_ver"] = None
+
+try:
+    env_info["pip_freeze"] = os.environ["pip_freeze"]
+except KeyError:
+    env_info["pip_freeze"] = None
+
+run_black = {}
+
+try:
+    run_black["start_black"] = os.environ["start_black"]
+except KeyError:
+    run_black["start_black"] = None
+
+try:
+    run_black["stop_black"] = os.environ["stop_black"]
+except KeyError:
+    run_black["stop_black"] = None
+
+metrics["black"] = run_black
+
+metrics["env_info"] = env_info
+
+with open("gen_json_check_formatting.json", "w", encoding="utf-8") as fio:
+    json.dump(metrics, fp=fio, ensure_ascii=False, indent=4)
+
+print(json.dumps(metrics, ensure_ascii=False, indent=4))

--- a/.github/workflows/gen_json_create_cache.py
+++ b/.github/workflows/gen_json_create_cache.py
@@ -1,0 +1,64 @@
+"""Generate json for md report.
+
+This python script is used to generate the json for the
+markdown report generated in the ``create-cache`` workflow job.
+"""
+
+import json
+import os
+
+metrics = {}
+
+metrics["name"] = "Check code formatting with black"
+metrics["job-id"] = "create-cache"
+
+env_info = {}
+
+try:
+    env_info["cache_hit"] = os.environ["cache_hit"]
+    if env_info["cache_hit"] == "true":
+        env_info["cache_hit"] = True
+    elif env_info["cache_hit"] == "false" or env_info["cache_hit"] == "":
+        env_info["cache_hit"] = False
+    else:
+        unknown_cache_hit_val = os.environ.get("cache_hit")
+        raise ValueError(f"Unknown value for key 'cache_hit':{unknown_cache_hit_val}")
+except KeyError:
+    env_info["cache_hit"] = None
+
+if not env_info["cache_hit"]:
+    # Cache didn't hit, venv was created, or something went wrong
+    create_venv = {}
+    try:
+        create_venv["start_create_venv"] = os.environ["start_create_venv"]
+    except KeyError:
+        create_venv["start_create_venv"] = None
+
+    try:
+        create_venv["stop_create_venv"] = os.environ["stop_create_venv"]
+    except KeyError:
+        create_venv["stop_create_venv"] = None
+
+    env_info["create_venv"] = create_venv
+
+try:
+    env_info["python_ver"] = os.environ["python_ver"]
+except KeyError:
+    env_info["python_ver"] = None
+
+try:
+    env_info["pip_ver"] = os.environ["pip_ver"]
+except KeyError:
+    env_info["pip_ver"] = None
+
+try:
+    env_info["pip_freeze"] = os.environ["pip_freeze"]
+except KeyError:
+    env_info["pip_freeze"] = None
+
+metrics["env_info"] = env_info
+
+with open("gen_json_create_cache.json", "w", encoding="utf-8") as fio:
+    json.dump(metrics, fp=fio, ensure_ascii=False, indent=4)
+
+print(json.dumps(metrics, ensure_ascii=False, indent=4))

--- a/.github/workflows/gen_json_test_code_quality.py
+++ b/.github/workflows/gen_json_test_code_quality.py
@@ -1,0 +1,91 @@
+"""Generate json for md report.
+
+This python script is used to generate the json for the
+markdown report generated in the workflow jobs.
+"""
+
+import json
+import os
+
+metrics = {}
+
+metrics["name"] = "Test with bandit, flake8, and pydocstyle"
+metrics["id"] = "test-code-quality"
+
+env_info = {}
+
+try:
+    env_info["cache_hit"] = os.environ["cache_hit"]
+    if env_info["cache_hit"] == "true":
+        env_info["cache_hit"] = True
+    elif env_info["cache_hit"] == "false" or env_info["cache_hit"] == "":
+        env_info["cache_hit"] = False
+    else:
+        unknown_cache_hit_val = os.environ.get("cache_hit")
+        raise ValueError(f"Unknown value for key 'cache_hit':{unknown_cache_hit_val}")
+except KeyError:
+    env_info["cache_hit"] = None
+
+try:
+    env_info["python_ver"] = os.environ["python_ver"]
+except KeyError:
+    env_info["python_ver"] = None
+
+try:
+    env_info["pip_ver"] = os.environ["pip_ver"]
+except KeyError:
+    env_info["pip_ver"] = None
+
+try:
+    env_info["pip_freeze"] = os.environ["pip_freeze"]
+except KeyError:
+    env_info["pip_freeze"] = None
+
+test_bandit = {}
+
+try:
+    test_bandit["start_bandit"] = os.environ["start_bandit"]
+except KeyError:
+    test_bandit["start_bandit"] = None
+
+try:
+    test_bandit["stop_bandit"] = os.environ["stop_bandit"]
+except KeyError:
+    test_bandit["stop_bandit"] = None
+
+metrics["bandit"] = test_bandit
+
+test_flake8 = {}
+
+try:
+    test_flake8["start_flake8"] = os.environ["start_flake8"]
+except KeyError:
+    test_flake8["start_flake8"] = None
+
+try:
+    test_flake8["stop_flake8"] = os.environ["stop_flake8"]
+except KeyError:
+    test_flake8["stop_flake8"] = None
+
+metrics["flake8"] = test_flake8
+
+test_pydocstyle = {}
+
+try:
+    test_pydocstyle["start_pydocstyle"] = os.environ["start_pydocstyle"]
+except KeyError:
+    test_pydocstyle["start_pydocstyle"] = None
+
+try:
+    test_pydocstyle["stop_pydocstyle"] = os.environ["stop_pydocstyle"]
+except KeyError:
+    test_pydocstyle["stop_pydocstyle"] = None
+
+metrics["pydocstyle"] = test_pydocstyle
+
+metrics["env_info"] = env_info
+
+with open("gen_json_test_code_quality.json", "w", encoding="utf-8") as fio:
+    json.dump(metrics, fp=fio, ensure_ascii=False, indent=4)
+
+print(json.dumps(metrics, ensure_ascii=False, indent=4))

--- a/.github/workflows/gen_json_test_mypy.py
+++ b/.github/workflows/gen_json_test_mypy.py
@@ -1,0 +1,63 @@
+"""Generate json for md report.
+
+This python script is used to generate the json for the
+markdown report generated in the workflow jobs.
+"""
+
+import json
+import os
+
+metrics = {}
+
+metrics["name"] = "Test with mypy"
+metrics["id"] = "test-mypy"
+
+env_info = {}
+
+try:
+    env_info["cache_hit"] = os.environ["cache_hit"]
+    if env_info["cache_hit"] == "true":
+        env_info["cache_hit"] = True
+    elif env_info["cache_hit"] == "false" or env_info["cache_hit"] == "":
+        env_info["cache_hit"] = False
+    else:
+        unknown_cache_hit_val = os.environ.get("cache_hit")
+        raise ValueError(f"Unknown value for key 'cache_hit':{unknown_cache_hit_val}")
+except KeyError:
+    env_info["cache_hit"] = None
+
+try:
+    env_info["python_ver"] = os.environ["python_ver"]
+except KeyError:
+    env_info["python_ver"] = None
+
+try:
+    env_info["pip_ver"] = os.environ["pip_ver"]
+except KeyError:
+    env_info["pip_ver"] = None
+
+try:
+    env_info["pip_freeze"] = os.environ["pip_freeze"]
+except KeyError:
+    env_info["pip_freeze"] = None
+
+test_mypy = {}
+
+try:
+    test_mypy["start_mypy"] = os.environ["start_mypy"]
+except KeyError:
+    test_mypy["start_mypy"] = None
+
+try:
+    test_mypy["stop_mypy"] = os.environ["stop_mypy"]
+except KeyError:
+    test_mypy["stop_mypy"] = None
+
+metrics["mypy"] = test_mypy
+
+metrics["env_info"] = env_info
+
+with open("gen_json_test_mypy.json", "w", encoding="utf-8") as fio:
+    json.dump(metrics, fp=fio, ensure_ascii=False, indent=4)
+
+print(json.dumps(metrics, ensure_ascii=False, indent=4))

--- a/.github/workflows/gen_json_test_pytest.py
+++ b/.github/workflows/gen_json_test_pytest.py
@@ -1,0 +1,63 @@
+"""Generate json for md report.
+
+This python script is used to generate the json for the
+markdown report generated in the workflow jobs.
+"""
+
+import json
+import os
+
+metrics = {}
+
+metrics["name"] = "Test with pytest"
+metrics["id"] = "test-pytest"
+
+env_info = {}
+
+try:
+    env_info["cache_hit"] = os.environ["cache_hit"]
+    if env_info["cache_hit"] == "true":
+        env_info["cache_hit"] = True
+    elif env_info["cache_hit"] == "false" or env_info["cache_hit"] == "":
+        env_info["cache_hit"] = False
+    else:
+        unknown_cache_hit_val = os.environ.get("cache_hit")
+        raise ValueError(f"Unknown value for key 'cache_hit':{unknown_cache_hit_val}")
+except KeyError:
+    env_info["cache_hit"] = None
+
+try:
+    env_info["python_ver"] = os.environ["python_ver"]
+except KeyError:
+    env_info["python_ver"] = None
+
+try:
+    env_info["pip_ver"] = os.environ["pip_ver"]
+except KeyError:
+    env_info["pip_ver"] = None
+
+try:
+    env_info["pip_freeze"] = os.environ["pip_freeze"]
+except KeyError:
+    env_info["pip_freeze"] = None
+
+test_pytest = {}
+
+try:
+    test_pytest["start_pytest"] = os.environ["start_pytest"]
+except KeyError:
+    test_pytest["start_pytest"] = None
+
+try:
+    test_pytest["stop_pytest"] = os.environ["stop_pytest"]
+except KeyError:
+    test_pytest["stop_pytest"] = None
+
+metrics["pytest"] = test_pytest
+
+metrics["env_info"] = env_info
+
+with open("gen_json_test_pytest.json", "w", encoding="utf-8") as fio:
+    json.dump(metrics, fp=fio, ensure_ascii=False, indent=4)
+
+print(json.dumps(metrics, ensure_ascii=False, indent=4))

--- a/.github/workflows/test_python-parallel.yaml
+++ b/.github/workflows/test_python-parallel.yaml
@@ -1,0 +1,351 @@
+# Action for testing Python code on a matrix
+# yamllint disable rule:line-length
+---
+name: Test Python code
+on: # yamllint disable-line rule:truthy rule:comments
+  pull_request:
+    branches:
+      - main
+
+env:
+  CI_TEST_ENV: "True"
+
+#                                           +---------------------+
+#                                           |                     |           +---------------+        +------+
+#                                      +--->+  CHECK FORMATTING   +---------->+ GEN MD REPORT +------->+ STOP |
+#                                      |    |                     |           ++--+--+--+-----+        +------+
+#                                      |    +---------------------+            ^  ^  ^  ^
+#                                      |                                       |  |  |  |
+#                                      |                                       |  |  |  |
+#              +-------------+         |    +---------------------+            |  |  |  |
+# +-------+    |             |         |    |                     |            |  |  |  |
+# |       |    |   CREATE    |         +--->+  TEST WITH PYTEST   +------------+  |  |  |
+# | START +--->+   PYTHON    +---------+    |                     |               |  |  |
+# |       |    |   CACHE     |         |    +---------------------+               |  |  |
+# +-------+    |             |         |                                          |  |  |
+#              +-----+-------+         |                                          |  |  |
+#                    |                 |    +---------------------+               |  |  |
+#                    |                 |    |                     |               |  |  |
+#                    |                 +--->+  TEST WITH MYPY     +---------------+  |  |
+#                    |                 |    |                     |                  |  |
+#                    |                 |    +---------------------+                  |  |
+#                    |                 |                                             |  |
+#                    |                 |                                             |  |
+#                    |                 |    +---------------------+                  |  |
+#                    |                 |    |                     |                  |  |
+#                    |                 |    |  TEST WITH :        |                  |  |
+#                    |                 |    |      BANDIT         +------------------+  |
+#                    |                 +--->+      FLAKE8         |                     |
+#                    |                      |      PYDOCSTYLE     |                     |
+#                    |                      |                     |                     |
+#                    |                      +---------------------+                     |
+#                    +------------------------------------------------------------------+
+# We start by creating a python cache that everyone can use, and then consuming it
+# within various jobs as they come up. The above ASCII diagram attempts to show how
+# the entire workflow works.
+
+jobs:
+  create-cache:
+    name: Create python cache if not present
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.10.7]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set environment variables for cache
+        id: set-env-var-cache
+        run: |
+          echo "python-version=$(python --version)" >> $GITHUB_ENV
+          echo "week-number=$(date "+%V")" >> $GITHUB_ENV
+      - name: Python cache
+        uses: actions/cache@v3
+        id: venv-cache
+        env:
+          cache-name: cache-python-env
+        with:
+          path: .venv
+          key: ${{ env.cache-name }}-${{ env.week-number }}-${{ runner.os }}-${{ env.python-version }}-${{ hashFiles('requirements*.txt') }}
+      - name: Create python environment
+        id: create-environment
+        if: ${{ steps.venv-cache.outputs.cache-hit == false }}
+        run: |
+          echo "start_create_venv=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          python -m venv .venv;
+          source .venv/bin/activate;
+          python -m pip install --upgrade pip;
+          python -m pip install --upgrade wheel;
+          python -m pip install -r requirements.txt;
+          python -m pip install -r requirements-dev.txt;
+          echo "stop_create_venv=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: debug file system
+        id: debug-file-system
+        run: |
+          ls
+      - name: Output env info
+        id: check-formatting-save-env-info
+        run: |
+          source .venv/bin/activate;
+          echo "cache_hit=${{ steps.venv-cache.outputs.cache-hit }}" >> $GITHUB_ENV
+          echo "python_ver=$(python --version)"  >> $GITHUB_ENV
+          echo "pip_ver=$(pip --version)"  >> $GITHUB_ENV
+          echo "pip_freeze=$(pip freeze | tr "\n" ";")"  >> $GITHUB_ENV
+      - name: Generate markdown report
+        id: gen-md-report
+        run: |
+          echo "# Create python cache if not present" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          python .github/workflows/gen_json_create_cache.py >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+  check-formatting:
+    name: Check code formatting with black
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.10.7]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 2
+    needs: [create-cache]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set environment variables for cache
+        id: set-env-var-cache
+        run: |
+          echo "python-version=$(python --version)" >> $GITHUB_ENV
+          echo "week-number=$(date "+%V")" >> $GITHUB_ENV
+      - name: Python environment cache
+        uses: actions/cache@v3
+        id: venv-cache
+        env:
+          cache-name: cache-python-env-formatting
+        with:
+          path: .venv
+          key: ${{ env.cache-name }}-${{ env.week-number }}-${{ runner.os }}-${{ env.python-version }}
+      - name: Check code formatting with black
+        id: check-formatting-run-black
+        run: |
+          source .venv/bin/activate;
+          echo "start_black=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          black --check .
+          echo "stop_black=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: Output env info
+        id: check-formatting-save-env-info
+        run: |
+          source .venv/bin/activate;
+          echo "cache_hit=${{ steps.venv-cache.outputs.cache-hit }}" >> $GITHUB_ENV
+          echo "python_ver=$(python --version)"  >> $GITHUB_ENV
+          echo "pip_ver=$(pip --version)"  >> $GITHUB_ENV
+          echo "pip_freeze=$(pip freeze | tr "\n" ";")"  >> $GITHUB_ENV
+      - name: Generate markdown report
+        id: gen-md-report
+        run: |
+          echo "# Check code formatting with black" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          python .github/workflows/gen_json_check_formatting.py >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+  test-pytest:
+    name: Test with pytest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.10.7]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    needs: [create-cache]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set environment variables for cache
+        id: set-env-var-cache
+        run: |
+          echo "python-version=$(python --version)" >> $GITHUB_ENV
+          echo "week-number=$(date "+%V")" >> $GITHUB_ENV
+      - name: Python environment cache
+        uses: actions/cache@v3
+        id: venv-cache
+        env:
+          cache-name: cache-python-env
+        with:
+          path: .venv
+          key: ${{ env.cache-name }}-${{ env.week-number }}-${{ runner.os }}-${{ env.python-version }}-${{ hashFiles('requirements*.txt') }}
+      - name: Activate python environment
+        id: activate-env
+        run: |
+          source .venv/bin/activate;
+      - name: Test with pytest
+        id: test-pytest
+        run: |
+          source .venv/bin/activate; # Activate python environment: this doesn't persist between steps
+          echo "start_pytest=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          pytest;
+          echo "stop_pytest=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: Output env info
+        id: check-formatting-save-env-info
+        run: |
+          source .venv/bin/activate;
+          echo "cache_hit=${{ steps.venv-cache.outputs.cache-hit }}" >> $GITHUB_ENV
+          echo "python_ver=$(python --version)"  >> $GITHUB_ENV
+          echo "pip_ver=$(pip --version)"  >> $GITHUB_ENV
+          echo "pip_freeze=$(pip freeze | tr "\n" ";")"  >> $GITHUB_ENV
+      - name: Generate markdown report
+        id: gen-md-report
+        run: |
+          echo "# Test with pytest, mypy, bandit, flake8, and pydocstyle" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          python .github/workflows/gen_json_test_pytest.py >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+  test-mypy:
+    name: Test with mypy
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.10.7]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 2
+    needs: [create-cache]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set environment variables for cache
+        id: set-env-var-cache
+        run: |
+          echo "python-version=$(python --version)" >> $GITHUB_ENV
+          echo "week-number=$(date "+%V")" >> $GITHUB_ENV
+      - name: Python environment cache
+        uses: actions/cache@v3
+        id: venv-cache
+        env:
+          cache-name: cache-python-env
+        with:
+          path: .venv
+          key: ${{ env.cache-name }}-${{ env.week-number }}-${{ runner.os }}-${{ env.python-version }}-${{ hashFiles('requirements*.txt') }}
+      - name: Activate python environment
+        id: activate-env
+        run: |
+          source .venv/bin/activate;
+      - name: Test with mypy
+        id: test-mypy
+        run: |
+          source .venv/bin/activate; # Activate python virtual environment: this doesn't persist between steps
+          echo "start_mypy=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          mypy;
+          echo "stop_mypy=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: Output env info
+        id: check-formatting-save-env-info
+        run: |
+          source .venv/bin/activate;
+          echo "cache_hit=${{ steps.venv-cache.outputs.cache-hit }}" >> $GITHUB_ENV
+          echo "python_ver=$(python --version)"  >> $GITHUB_ENV
+          echo "pip_ver=$(pip --version)"  >> $GITHUB_ENV
+          echo "pip_freeze=$(pip freeze | tr "\n" ";")"  >> $GITHUB_ENV
+      - name: Generate markdown report
+        id: gen-md-report
+        run: |
+          echo "# Test with pytest, mypy, bandit, flake8, and pydocstyle" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          python .github/workflows/gen_json_test_mypy.py >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+  test-code-quality:
+    name: Test with bandit, flake8, pydocstyle
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.10.7]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 2
+    needs: [create-cache]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set environment variables for cache
+        id: set-env-var-cache
+        run: |
+          echo "python-version=$(python --version)" >> $GITHUB_ENV
+          echo "week-number=$(date "+%V")" >> $GITHUB_ENV
+      - name: Python environment cache
+        uses: actions/cache@v3
+        id: venv-cache
+        env:
+          cache-name: cache-python-env
+        with:
+          path: .venv
+          key: ${{ env.cache-name }}-${{ env.week-number }}-${{ runner.os }}-${{ env.python-version }}-${{ hashFiles('requirements*.txt') }}
+      - name: Activate python environment
+        id: activate-env
+        run: |
+          source .venv/bin/activate;
+      - name: Test with bandit
+        id: test-bandit
+        run: |
+          source .venv/bin/activate;
+          echo "start_bandit=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          bandit --ini .bandit;
+          echo "stop_bandit=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: Test with flake8
+        id: test-flake8
+        run: |
+          source .venv/bin/activate;
+          echo "start_flake8=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          flake8;
+          echo "stop_flake8=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: Test with pydocstyle
+        id: test-pydocstyle
+        run: |
+          source .venv/bin/activate;
+          echo "start_pydocstyle=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+          pydocstyle;
+          echo "stop_pydocstyle=$(TZ=UTC date --rfc-3339=ns)"  >> $GITHUB_ENV
+      - name: Output env info
+        id: check-formatting-save-env-info
+        run: |
+          source .venv/bin/activate;
+          echo "cache_hit=${{ steps.venv-cache.outputs.cache-hit }}" >> $GITHUB_ENV
+          echo "python_ver=$(python --version)"  >> $GITHUB_ENV
+          echo "pip_ver=$(pip --version)"  >> $GITHUB_ENV
+          echo "pip_freeze=$(pip freeze | tr "\n" ";")"  >> $GITHUB_ENV
+      - name: Generate markdown report
+        id: gen-md-report
+        run: |
+          echo "# Test with pytest, mypy, bandit, flake8, and pydocstyle" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          python .github/workflows/gen_json_test_code_quality.py >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --verbose --strict-markers
+addopts = --verbose --strict-markers --durations=10 --durations-min=0.01
 minversion = 7.1.2
 pythonpath = ./
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
Create parallel CI python file

Create a GitHub actions workflow file that runs CI jobs in parallel.

As the size of a code base increases the jobs in a CI pipeline scale up to accommodate
the code base. This means tests can take longer to run and static analyzers can hold up
the entire pipeline. If the jobs run in sequence, then the CI pipeline takes up time
equal to the total cumulative run time of all the jobs. If they run in parallel, then
the CI pipeline runs only as long as the longest running job. Further, jobs which
complete can report their results without waiting for the rest of the pipeline to
run it's course. Also, resiliency of the pipeline increases since individual jobs
can fail without breaking the entire pipeline. Developers can work on optimizing
individual jobs in the pipeline, without accidentally rendering the entire pipeline
useless. Thus, a new workflow file has been created for a parallel CI pipeline.

Closes #19.