### PR TITLE
fix: prevent duplicate run of GitHub actions

### DIFF
--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -3,9 +3,6 @@
 ---
 name: Test Python
 on: # yamllint disable-line rule:truthy rule:comments
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Prevent this GitHub Actions workflow from running after push to `main`.

This workflow runs whenever there is a push to `main` branch of the repository. This includes after there is a pull request that is merged or squashed. Since we are doing trunk development, there is no need for a duplicate run.

Closes #20.