### PR TITLE
Add `CI` and `CI_TEST_ENV` information to JSON report

### DIFF
--- a/.github/workflows/gen_json_test.py
+++ b/.github/workflows/gen_json_test.py
@@ -21,6 +21,16 @@ except KeyError:
 env_info = {}
 
 try:
+    env_info["CI"] = os.environ["CI"]
+except KeyError:
+    env_info["CI"] = "ERROR: CI env variable is missing"
+
+try:
+    env_info["CI_TEST_ENV"] = os.environ["CI_TEST_ENV"]
+except KeyError:
+    env_info["CI_TEST_ENV"] = "ERROR: CI_TEST_ENV env variable is missing"
+
+try:
     env_info["cache_hit"] = os.environ["cache_hit"]
     if env_info["cache_hit"] == "true":
         env_info["cache_hit"] = True


### PR DESCRIPTION
Add `CI` and `CI_TEST_ENV` information to JSON report for sequential python workflow.

Closes #86.