### PR TITLE
fix:first doc line needs a . in parallel workflow

### DIFF
--- a/.github/workflows/test_python-parallel.yaml
+++ b/.github/workflows/test_python-parallel.yaml
@@ -1,4 +1,4 @@
-# Action for testing Python code on a matrix
+# Action for testing Python code on a matrix.
 # yamllint disable rule:line-length
 #                                           +---------------------+
 #                                           |                     |           +---------------+        +------+


### PR DESCRIPTION
First line is missing a `.` in the documentation of the parallel python workflow file.

Closes #81.