### PR TITLE
Add `slow` marker to pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ python_files = tests.py test_*.py *_tests.py
 asyncio_mode = strict
 testpaths =
     tests/
+markers =
+    slow: mark test as slow(deselect with `-m "not slow"`)


### PR DESCRIPTION
Add `slow` custom marker to pytest configuration.

Tests that are slow should be marked appropriately with a custom marker `slow`. Tests marked as `slow` can be run independently of other tests, or excluded from a test run.

Closes #90.